### PR TITLE
test: adding mask test to two_point_stats

### DIFF
--- a/pymks/fmks/correlations.py
+++ b/pymks/fmks/correlations.py
@@ -165,6 +165,17 @@ def two_point_stats(arr1, arr2, mask=None, periodic_boundary=True, cutoff=None):
     ... ).shape
     (2, 5)
 
+    Test masking
+
+    >>> array = np.array([[[1, 0 ,0], [0, 1, 1], [1, 1, 0]]])
+    >>> mask = np.array([[[1, 1, 1], [1, 1, 1], [1, 0, 0]]])
+    >>> norm_mask = np.array([[[2, 4, 3], [4, 7, 4], [3, 4, 2]]])
+    >>> expected = np.array([[[1, 0, 1], [1, 4, 1], [1, 0, 1]]]) / norm_mask
+    >>> assert np.allclose(
+    ...     two_point_stats(array, array, mask=mask),
+    ...     expected
+    ... )
+
     """
     if mask is not None:
         assert (


### PR DESCRIPTION
Duplicate a test for masking with two_point_stats in the doctest to
force 100% code coverage. Unfortunately, the masking tests are in a
notebook and these aren't yet being included in the code coverage.